### PR TITLE
Add landing page and move calendar

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,7 +26,7 @@
 
     <nav id="navbar" class="navbar">
         <ul>
-            <li><a href="index.html">Kalender</a></li>
+            <li><a href="calendar.html">Kalender</a></li>
             <li><a href="about.html">Om oss</a></li>
             <li><a href="contact.html">Kontakt</a></li>
             <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kalender - MinTurnus</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel="icon" type="image/x-icon" href="images/favicon.ico">
+<link rel="icon" type="image/png" sizes="32x32" href="images/favicon.png">
+<link rel="apple-touch-icon" href="images/icon-512.png">
+        <link rel="stylesheet" href="css/style.css">
+        <link rel="stylesheet" href="css/header.css">
+        <link rel="stylesheet" href="css/calendar.css">
+    <link rel="stylesheet" href="css/user_profile.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
+    <script defer src="js/bundle.min.js"></script>
+</head>
+<body>
+    <header class="header">
+        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <div class="user-container">
+        <div id="user-info"></div>
+        </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
+        <div id="hamburger" class="hamburger">&#9776;</div>
+    </header>
+        <nav id="navbar" class="navbar">
+            <ul>
+                <li><a href="calendar.html">Kalender</a></li>
+                <li><a href="about.html">Om oss</a></li>
+                <li><a href="contact.html">Kontakt</a></li>
+                <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>
+                <li id="profile-item" style="display:none;"><a href="user_profile.html">Min profil</a></li>
+                <li><a href="login.html" id="login-link">Logg inn</a></li>
+            </ul>
+        </nav>
+    <!-- Kalender -->
+    <div class="container">
+        <div class="calendar-header">
+            <div class="calendar-top">
+                <h2 id="month-year" class="page-title">Oktober 2024</h2>
+                <div class="calendar-top-buttons">
+                    <button id="today-button" class="nav-button">I dag</button>
+                    <button id="toggle-year" class="nav-button">Vis år</button>
+                </div>
+            </div>
+            <div class="calendar-nav">
+                <button id="prev-month" class="nav-button">← Forrige</button>
+                <button id="next-month" class="nav-button">Neste →</button>
+            </div>
+        </div>
+        <div class="weekday-row">
+            <div class="weekday">MON</div>
+            <div class="weekday">TIR</div>
+            <div class="weekday">ONS</div>
+            <div class="weekday">TOR</div>
+            <div class="weekday">FRE</div>
+            <div class="weekday">LØR</div>
+            <div class="weekday">SØN</div>
+        </div>
+        <div class="calendar-grid"></div>
+        <div id="day-popup" class="day-popup" style="display:none;"></div>
+        <div id="year-container" class="year-container"></div>
+        <div id="turnus-oversikt" class="turnus-oversikt"></div>
+
+        <div id="colleague-section" class="colleague-section" style="display:none;">
+            <h3>Kollegaer i kalenderen</h3>
+            <p class="colleague-info">Her ser du kollegaer du allerede har lagt til. For å legge til nye kollegaer, gå til kollega-siden eller <a href="friends.html">trykk her</a>.</p>
+            <div class="colleague-buttons">
+                <button id="colleagues-all" class="action-btn">Alle</button>
+                <button id="colleagues-none" class="action-btn">Ingen</button>
+                <button id="colleagues-close" class="action-btn">Nære kollegaer</button>
+            </div>
+            <label for="colleague-search">Filtrer kollegaene nedenfor</label>
+            <input type="text" id="colleague-search" placeholder="Filtrer blant eksisterende kollegaer">
+            <div id="colleague-list" class="colleague-list">
+                <div id="user-shift-toggle" class="user-shift-toggle" style="display:none;">
+                    <label><input type="checkbox" id="show-user-shift"> <span id="user-shift-label"></span></label>
+                </div>
+            </div>
+        </div>
+
+    <div id="deviation-section">
+        <button id="toggle-deviation" class="btn" style="display:none;">Legg til avvik fra turnus</button>
+        <form id="deviation-form" class="shift-form" style="display:none;">
+            <input type="hidden" name="csrf_token" value="">
+            <h3>Avvik fra egen turnus</h3>
+            <label for="deviation-start">Startdato</label>
+            <input type="date" id="deviation-start">
+
+            <label for="deviation-pattern">Midlertidig turnus</label>
+            <select id="deviation-pattern">
+                <option value="0-1">0-1</option>
+                <option value="0-2">0-2</option>
+                <option value="0-3">0-3</option>
+                <option value="0-4">0-4</option>
+                <option value="0-5">0-5</option>
+                <option value="1-1">1-1</option>
+                <option value="1-2">1-2</option>
+                <option value="1-3">1-3</option>
+                <option value="1-4">1-4</option>
+                <option value="2-1">2-1</option>
+                <option value="2-2">2-2</option>
+                <option value="2-3">2-3</option>
+                <option value="2-4">2-4</option>
+                <option value="2-6">2-6</option>
+                <option value="3-1">3-1</option>
+                <option value="3-2">3-2</option>
+                <option value="3-3">3-3</option>
+                <option value="3-4">3-4</option>
+                <option value="4-4">4-4</option>
+                <option value="4-5">4-5</option>
+                <option value="4-8">4-8</option>
+                <option value="5-5">5-5</option>
+            </select>
+
+            <label for="deviation-behavior">Etter avvik</label>
+            <select id="deviation-behavior">
+                <option value="keep">Fortsett med original rytme</option>
+                <option value="shift">Fortsett fra slutten av avviket</option>
+            </select>
+
+            <button type="button" id="save-deviation" class="btn">Lagre avvik</button>
+        </form>
+        <div id="deviation-list" class="shift-list"></div>
+    </div>
+    <div class="shift-form">
+        <h3>Legg til ny turnus manuelt</h3>
+        <div class="info-box" id="manual-shift-info">
+            <span class="info-icon">🛈</span>
+            <span>Dette skjemaet brukes til å legge til generelle turnuser i kalenderen. Ønsker du å lagre din egen turnus og dele med kollegaer? <a href="register.html">Opprett en profil her</a>.</span>
+        </div>
+        
+        <label for="shift-name">Navn på turnus:</label>
+        <input type="text" id="shift-name" placeholder="Eks: Thomas">
+        
+        <label for="shift-duration">Turnus lengde:</label>
+        <select id="shift-duration">
+            <!-- Forhåndsdefinerte turnuser -->
+            <option value="mandag-fredag">Mandag til fredag</option>
+            <option value="1-1">1-1</option>
+            <option value="1-2">1-2</option>
+            <option value="1-3">1-3</option>
+            <option value="1-4">1-4</option>
+            <option value="2-1">2-1</option>
+            <option value="2-2">2-2</option>
+            <option value="2-3">2-3</option>
+            <option value="2-4">2-4</option>
+            <option value="2-6">2-6</option>
+            <option value="3-1">3-1</option>
+            <option value="3-2">3-2</option>
+            <option value="3-3">3-3</option>
+            <option value="3-4">3-4</option>
+            <option value="4-4">4-4</option>
+            <option value="4-5">4-5</option>
+            <option value="4-8">4-8</option>
+            <option value="5-5">5-5</option>
+            <option value="custom">Valgfritt...</option>
+        </select>
+                
+        <label for="shift-start">Første skiftdag</label>
+        <input type="date" id="shift-start">
+        
+        
+        <button id="add-shift" class="btn">Legg til turnus</button>
+        <button id="reset" class="btn-secondary">Tøm skjema</button>
+        <div id="message"></div>
+    </div>
+
+
+    <!-- Kolonnetitler for turnuslisten -->
+    <div class="shift-list-header">
+        <span class="shift-header">Velg</span>
+        <span class="shift-header">Navn på turnus</span>
+        <span class="shift-header">Turnus</span>
+        <span class="shift-header">Handling</span>
+    </div>
+
+    <!-- Liste over aktive turnuser med mulighet for sletting og skjuling -->
+    <div id="shift-list" class="shift-list"></div>
+
+</div>
+
+<div id="colleague-modal" class="modal">
+    <div class="modal-content">
+        <span id="colleague-close" class="close">&times;</span>
+        <div id="colleague-content"></div>
+    </div>
+</div>
+
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
+    </div>
+
+
+</body>
+</html>

--- a/change_password.html
+++ b/change_password.html
@@ -26,7 +26,7 @@
 
     <nav id="navbar" class="navbar">
         <ul>
-            <li><a href="index.html">Kalender</a></li>
+            <li><a href="calendar.html">Kalender</a></li>
             <li><a href="about.html">Om oss</a></li>
             <li><a href="contact.html">Kontakt</a></li>
             <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/contact.html
+++ b/contact.html
@@ -27,7 +27,7 @@
 
     <nav id="navbar" class="navbar">
         <ul>
-            <li><a href="index.html">Kalender</a></li>
+            <li><a href="calendar.html">Kalender</a></li>
             <li><a href="about.html">Om oss</a></li>
             <li><a href="contact.html">Kontakt</a></li>
             <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -582,3 +582,19 @@ a:hover {
     from { opacity: 0; transform: scale(0.95); }
     to   { opacity: 1; transform: scale(1);   }
 }
+
+/* Landing page hero section */
+.hero {
+    background-color: var(--secondary-color);
+    padding: 60px 20px;
+    text-align: center;
+}
+.hero h2 {
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+    color: var(--primary-color);
+}
+.hero p {
+    margin-bottom: 20px;
+    font-size: 1.2rem;
+}

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -25,7 +25,7 @@
 
     <nav id="navbar" class="navbar">
         <ul>
-            <li><a href="index.html">Kalender</a></li>
+            <li><a href="calendar.html">Kalender</a></li>
             <li><a href="about.html">Om oss</a></li>
             <li><a href="contact.html">Kontakt</a></li>
             <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/friends.html
+++ b/friends.html
@@ -30,7 +30,7 @@
 
 <nav id="navbar" class="navbar">
     <ul>
-        <li><a href="index.html">Kalender</a></li>
+        <li><a href="calendar.html">Kalender</a></li>
         <li><a href="about.html">Om oss</a></li>
         <li><a href="contact.html">Kontakt</a></li>
         <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/index.html
+++ b/index.html
@@ -3,15 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Kalender - MinTurnus</title>
+    <title>Velkommen til MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
-<link rel="icon" type="image/x-icon" href="images/favicon.ico">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon.png">
-<link rel="apple-touch-icon" href="images/icon-512.png">
-        <link rel="stylesheet" href="css/style.css">
-        <link rel="stylesheet" href="css/header.css">
-        <link rel="stylesheet" href="css/calendar.css">
-    <link rel="stylesheet" href="css/user_profile.css">
+    <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon.png">
+    <link rel="apple-touch-icon" href="images/icon-512.png">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/bundle.min.js"></script>
 </head>
@@ -19,175 +17,29 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-        <div id="user-info"></div>
+            <div id="user-info"></div>
         </div>
         <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
-        <nav id="navbar" class="navbar">
-            <ul>
-                <li><a href="index.html">Kalender</a></li>
-                <li><a href="about.html">Om oss</a></li>
-                <li><a href="contact.html">Kontakt</a></li>
-                <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>
-                <li id="profile-item" style="display:none;"><a href="user_profile.html">Min profil</a></li>
-                <li><a href="login.html" id="login-link">Logg inn</a></li>
-            </ul>
-        </nav>
-    <!-- Kalender -->
-    <div class="container">
-        <div class="calendar-header">
-            <div class="calendar-top">
-                <h2 id="month-year" class="page-title">Oktober 2024</h2>
-                <div class="calendar-top-buttons">
-                    <button id="today-button" class="nav-button">I dag</button>
-                    <button id="toggle-year" class="nav-button">Vis år</button>
-                </div>
-            </div>
-            <div class="calendar-nav">
-                <button id="prev-month" class="nav-button">← Forrige</button>
-                <button id="next-month" class="nav-button">Neste →</button>
-            </div>
-        </div>
-        <div class="weekday-row">
-            <div class="weekday">MON</div>
-            <div class="weekday">TIR</div>
-            <div class="weekday">ONS</div>
-            <div class="weekday">TOR</div>
-            <div class="weekday">FRE</div>
-            <div class="weekday">LØR</div>
-            <div class="weekday">SØN</div>
-        </div>
-        <div class="calendar-grid"></div>
-        <div id="day-popup" class="day-popup" style="display:none;"></div>
-        <div id="year-container" class="year-container"></div>
-        <div id="turnus-oversikt" class="turnus-oversikt"></div>
-
-        <div id="colleague-section" class="colleague-section" style="display:none;">
-            <h3>Kollegaer i kalenderen</h3>
-            <p class="colleague-info">Her ser du kollegaer du allerede har lagt til. For å legge til nye kollegaer, gå til kollega-siden eller <a href="friends.html">trykk her</a>.</p>
-            <div class="colleague-buttons">
-                <button id="colleagues-all" class="action-btn">Alle</button>
-                <button id="colleagues-none" class="action-btn">Ingen</button>
-                <button id="colleagues-close" class="action-btn">Nære kollegaer</button>
-            </div>
-            <label for="colleague-search">Filtrer kollegaene nedenfor</label>
-            <input type="text" id="colleague-search" placeholder="Filtrer blant eksisterende kollegaer">
-            <div id="colleague-list" class="colleague-list">
-                <div id="user-shift-toggle" class="user-shift-toggle" style="display:none;">
-                    <label><input type="checkbox" id="show-user-shift"> <span id="user-shift-label"></span></label>
-                </div>
-            </div>
-        </div>
-
-    <div id="deviation-section">
-        <button id="toggle-deviation" class="btn" style="display:none;">Legg til avvik fra turnus</button>
-        <form id="deviation-form" class="shift-form" style="display:none;">
-            <input type="hidden" name="csrf_token" value="">
-            <h3>Avvik fra egen turnus</h3>
-            <label for="deviation-start">Startdato</label>
-            <input type="date" id="deviation-start">
-
-            <label for="deviation-pattern">Midlertidig turnus</label>
-            <select id="deviation-pattern">
-                <option value="0-1">0-1</option>
-                <option value="0-2">0-2</option>
-                <option value="0-3">0-3</option>
-                <option value="0-4">0-4</option>
-                <option value="0-5">0-5</option>
-                <option value="1-1">1-1</option>
-                <option value="1-2">1-2</option>
-                <option value="1-3">1-3</option>
-                <option value="1-4">1-4</option>
-                <option value="2-1">2-1</option>
-                <option value="2-2">2-2</option>
-                <option value="2-3">2-3</option>
-                <option value="2-4">2-4</option>
-                <option value="2-6">2-6</option>
-                <option value="3-1">3-1</option>
-                <option value="3-2">3-2</option>
-                <option value="3-3">3-3</option>
-                <option value="3-4">3-4</option>
-                <option value="4-4">4-4</option>
-                <option value="4-5">4-5</option>
-                <option value="4-8">4-8</option>
-                <option value="5-5">5-5</option>
-            </select>
-
-            <label for="deviation-behavior">Etter avvik</label>
-            <select id="deviation-behavior">
-                <option value="keep">Fortsett med original rytme</option>
-                <option value="shift">Fortsett fra slutten av avviket</option>
-            </select>
-
-            <button type="button" id="save-deviation" class="btn">Lagre avvik</button>
-        </form>
-        <div id="deviation-list" class="shift-list"></div>
-    </div>
-    <div class="shift-form">
-        <h3>Legg til ny turnus manuelt</h3>
-        <div class="info-box" id="manual-shift-info">
-            <span class="info-icon">🛈</span>
-            <span>Dette skjemaet brukes til å legge til generelle turnuser i kalenderen. Ønsker du å lagre din egen turnus og dele med kollegaer? <a href="register.html">Opprett en profil her</a>.</span>
-        </div>
-        
-        <label for="shift-name">Navn på turnus:</label>
-        <input type="text" id="shift-name" placeholder="Eks: Thomas">
-        
-        <label for="shift-duration">Turnus lengde:</label>
-        <select id="shift-duration">
-            <!-- Forhåndsdefinerte turnuser -->
-            <option value="mandag-fredag">Mandag til fredag</option>
-            <option value="1-1">1-1</option>
-            <option value="1-2">1-2</option>
-            <option value="1-3">1-3</option>
-            <option value="1-4">1-4</option>
-            <option value="2-1">2-1</option>
-            <option value="2-2">2-2</option>
-            <option value="2-3">2-3</option>
-            <option value="2-4">2-4</option>
-            <option value="2-6">2-6</option>
-            <option value="3-1">3-1</option>
-            <option value="3-2">3-2</option>
-            <option value="3-3">3-3</option>
-            <option value="3-4">3-4</option>
-            <option value="4-4">4-4</option>
-            <option value="4-5">4-5</option>
-            <option value="4-8">4-8</option>
-            <option value="5-5">5-5</option>
-            <option value="custom">Valgfritt...</option>
-        </select>
-                
-        <label for="shift-start">Første skiftdag</label>
-        <input type="date" id="shift-start">
-        
-        
-        <button id="add-shift" class="btn">Legg til turnus</button>
-        <button id="reset" class="btn-secondary">Tøm skjema</button>
-        <div id="message"></div>
-    </div>
-
-
-    <!-- Kolonnetitler for turnuslisten -->
-    <div class="shift-list-header">
-        <span class="shift-header">Velg</span>
-        <span class="shift-header">Navn på turnus</span>
-        <span class="shift-header">Turnus</span>
-        <span class="shift-header">Handling</span>
-    </div>
-
-    <!-- Liste over aktive turnuser med mulighet for sletting og skjuling -->
-    <div id="shift-list" class="shift-list"></div>
-
-</div>
-
-<div id="colleague-modal" class="modal">
-    <div class="modal-content">
-        <span id="colleague-close" class="close">&times;</span>
-        <div id="colleague-content"></div>
-    </div>
-</div>
-
+    <nav id="navbar" class="navbar">
+        <ul>
+            <li><a href="calendar.html">Kalender</a></li>
+            <li><a href="about.html">Om oss</a></li>
+            <li><a href="contact.html">Kontakt</a></li>
+            <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>
+            <li id="profile-item" style="display:none;"><a href="user_profile.html">Min profil</a></li>
+            <li><a href="login.html" id="login-link">Logg inn</a></li>
+        </ul>
+    </nav>
+    <main class="hero">
+        <h2>Planlegg vaktlistene dine enkelt</h2>
+        <p>MinTurnus lar deg holde oversikt over din turnus og samarbeide med kollegaer.</p>
+        <a href="register.html" class="btn">Kom i gang</a>
+    </main>
+    <footer class="footer">
+        <p>&copy; 2025 MinTurnus.no - <a href="about.html">Personvernerklæring</a></p>
+    </footer>
 
     <div id="cookie-banner" class="cookie-banner">
         <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
@@ -196,7 +48,5 @@
             <button id="reject-cookies" class="btn-secondary">Avslå</button>
         </div>
     </div>
-
-
 </body>
 </html>

--- a/js/login.js
+++ b/js/login.js
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         if (action === 'register') {
                             window.location.href = 'user_profile.html';
                         } else {
-                            window.location.href = 'index.html';
+                            window.location.href = 'calendar.html';
                         }
                     } else {
                         showMessage('Innlogging feilet. Sjekk brukernavn og passord.', 'error');

--- a/login.html
+++ b/login.html
@@ -27,7 +27,7 @@
     </header>
         <nav id="navbar" class="navbar">
             <ul>
-                <li><a href="index.html">Kalender</a></li>
+                <li><a href="calendar.html">Kalender</a></li>
                 <li><a href="about.html">Om oss</a></li>
                 <li><a href="contact.html">Kontakt</a></li>
                 <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/register.html
+++ b/register.html
@@ -26,7 +26,7 @@
     
     <nav id="navbar" class="navbar">
         <ul>
-            <li><a href="index.html">Kalender</a></li>
+            <li><a href="calendar.html">Kalender</a></li>
             <li><a href="about.html">Om oss</a></li>
             <li><a href="contact.html">Kontakt</a></li>
             <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/reset_password.html
+++ b/reset_password.html
@@ -25,7 +25,7 @@
 
     <nav id="navbar" class="navbar">
         <ul>
-            <li><a href="index.html">Kalender</a></li>
+            <li><a href="calendar.html">Kalender</a></li>
             <li><a href="about.html">Om oss</a></li>
             <li><a href="contact.html">Kontakt</a></li>
             <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/user_profile.html
+++ b/user_profile.html
@@ -27,7 +27,7 @@
 
     <nav id="navbar" class="navbar">
         <ul>
-            <li><a href="index.html">Kalender</a></li>
+            <li><a href="calendar.html">Kalender</a></li>
             <li><a href="about.html">Om oss</a></li>
             <li><a href="contact.html">Kontakt</a></li>
             <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>

--- a/venn.html
+++ b/venn.html
@@ -25,7 +25,7 @@
 </header>
 <nav id="navbar" class="navbar">
     <ul>
-        <li><a href="index.html">Kalender</a></li>
+        <li><a href="calendar.html">Kalender</a></li>
         <li><a href="about.html">Om oss</a></li>
         <li><a href="contact.html">Kontakt</a></li>
         <li id="friends-item" style="display:none;"><a href="friends.html" id="friends-link">Kollegaer<span id="pending-count" class="badge"></span></a></li>


### PR DESCRIPTION
## Summary
- move the old calendar page to `calendar.html`
- create new `index.html` landing page with hero section
- update menu links on all pages to point to the new calendar location
- adjust login redirect to `calendar.html`
- add hero section styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685989188e10833388773a40db12fdb2