### PR TITLE
Make Turnus orange in index page logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
     h1, h2, h3 {
       font-family: 'Montserrat', sans-serif;
     }
+    .accent-text {
+      color: #F4A300;
+    }
     .btn-primary {
       background: linear-gradient(90deg, #F97316, #FB923C);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -38,7 +41,7 @@
   <!-- Navigasjon -->
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
-      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="text-orange-500">Turnus</span></a>
+      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
       <div id="navLinks" class="hidden md:flex space-x-6">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>


### PR DESCRIPTION
## Summary
- style `.accent-text` for the brand color
- use the accent color for "Turnus" in the homepage logo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859a4a9ca9883338c5df0d863596324