### PR TITLE
Fix mobile menu, cookie banner and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,13 +35,16 @@
     .card:hover {
       transform: translateY(-5px);
     }
+    .nav-active {
+      transform: translateX(0);
+    }
   </style>
 </head>
 <body class="antialiased">
   <!-- Navigasjon -->
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
-      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="text-orange-500">Turnus</span></a>
+      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
@@ -91,7 +94,7 @@
   </div>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-white py-8 text-center">
+  <footer class="bg-gray-900 text-white py-8 text-center fixed bottom-0 left-0 w-full">
     <p>© 2025 MinTurnus.no | <a href="privacy.html" class="text-orange-400 hover:underline">Personvernerklæring</a></p>
   </footer>
 
@@ -134,11 +137,17 @@
   const acceptCookies = document.getElementById('accept-cookies');
   const declineCookies = document.getElementById('decline-cookies');
 
+  if (localStorage.getItem('cookieConsent')) {
+    cookieConsent.classList.add('hidden');
+  }
+
   acceptCookies.addEventListener('click', () => {
+    localStorage.setItem('cookieConsent', 'accepted');
     cookieConsent.classList.add('hidden');
   });
 
   declineCookies.addEventListener('click', () => {
+    localStorage.setItem('cookieConsent', 'declined');
     cookieConsent.classList.add('hidden');
   });
   </script>

--- a/login.html
+++ b/login.html
@@ -33,6 +33,9 @@
       .card:hover {
         transform: translateY(-5px);
       }
+      .nav-active {
+        transform: translateX(0);
+      }
     </style>
 
 </head>
@@ -40,7 +43,7 @@
   <!-- Navigasjon -->
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
-      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="text-orange-500">Turnus</span></a>
+      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
@@ -96,7 +99,7 @@
   </div>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-white py-8 text-center mt-12">
+  <footer class="bg-gray-900 text-white py-8 text-center mt-12 fixed bottom-0 left-0 w-full">
     <p>© 2025 MinTurnus.no | <a href="privacy.html" class="text-orange-400 hover:underline">Personvernerklæring</a></p>
   </footer>
 
@@ -139,11 +142,17 @@
     const acceptCookies = document.getElementById('accept-cookies');
     const declineCookies = document.getElementById('decline-cookies');
 
+    if (localStorage.getItem('cookieConsent')) {
+      cookieConsent.classList.add('hidden');
+    }
+
     acceptCookies.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
       cookieConsent.classList.add('hidden');
     });
 
     declineCookies.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'declined');
       cookieConsent.classList.add('hidden');
     });
   </script>

--- a/register.html
+++ b/register.html
@@ -32,13 +32,16 @@
       .card:hover {
         transform: translateY(-5px);
       }
+      .nav-active {
+        transform: translateX(0);
+      }
     </style>
 </head>
 <body class="antialiased">
   <!-- Navigasjon -->
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
-      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="text-orange-500">Turnus</span></a>
+      <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
@@ -119,7 +122,7 @@
   </div>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-white py-8 text-center mt-12">
+  <footer class="bg-gray-900 text-white py-8 text-center mt-12 fixed bottom-0 left-0 w-full">
     <p>© 2025 MinTurnus.no | <a href="privacy.html" class="text-orange-400 hover:underline">Personvernerklæring</a></p>
   </footer>
 
@@ -162,11 +165,17 @@
     const acceptCookies = document.getElementById('accept-cookies');
     const declineCookies = document.getElementById('decline-cookies');
 
+    if (localStorage.getItem('cookieConsent')) {
+      cookieConsent.classList.add('hidden');
+    }
+
     acceptCookies.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
       cookieConsent.classList.add('hidden');
     });
 
     declineCookies.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'declined');
       cookieConsent.classList.add('hidden');
     });
   </script>


### PR DESCRIPTION
## Summary
- ensure mobile menu slides in on index, login and register pages
- make "Turnus" text use the accent color
- remember cookie consent using localStorage
- keep footer fixed at the bottom of the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859c81d704c833399b90fa2bf427d06