### PR TITLE
Fix missing calendar script

### DIFF
--- a/kalender.html
+++ b/kalender.html
@@ -585,6 +585,6 @@
     // Dummy CSRF-token for kompatibilitet med kalender.js
     window.CSRF_TOKEN = 'dummy-token'; // Erstatt med ekte token fra server
   </script>
-  <script src="/kalender.js"></script>
+  <script src="js/kalender.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point kalender.html to the actual script location

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859ccb546f08333b9f658b3ee0ca99a