### PR TITLE
Fix calendar script path and hide colleagues when logged out

### DIFF
--- a/js/kalender.js
+++ b/js/kalender.js
@@ -558,6 +558,11 @@ function saveShiftsToLocalStorage() {
 }
 
 function loadSelectedColleagues() {
+    if (!localStorage.getItem('userName')) {
+        localStorage.removeItem('selectedColleagues');
+        selectedColleagues = [];
+        return;
+    }
     const stored = localStorage.getItem('selectedColleagues');
     if (stored) {
         selectedColleagues = JSON.parse(stored);

--- a/kalender.html
+++ b/kalender.html
@@ -364,7 +364,7 @@
     </section>
 
     <!-- Kollegaseksjon -->
-    <section class="colleague-section mb-12">
+    <section id="colleague-section" class="colleague-section mb-12">
       <h2 class="text-2xl font-semibold text-gray-900 mb-3">Kollegaer i kalenderen</h2>
       <p class="text-gray-700 mb-4">Her ser du kollegaer du allerede har lagt til. For å legge til nye kollegaer, gå til kollega-siden eller <a href="/kollegaer.html" class="text-orange-500 underline">trykk her</a>.</p>
       <div class="colleague-buttons flex gap-2 mb-4">
@@ -585,6 +585,6 @@
     // Dummy CSRF-token for kompatibilitet med kalender.js
     window.CSRF_TOKEN = 'dummy-token'; // Erstatt med ekte token fra server
   </script>
-  <script src="/kalender.js"></script>
+  <script src="js/kalender.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point calendar page script tag at `js/kalender.js`
- ensure colleague section has correct ID for session script
- clear selected colleagues when not logged in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859cd9f5c6c8333ba51a55cf8d74e82