### PR TITLE
Adjust calendar layout and login visibility

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -8,13 +8,15 @@
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
+
 .container.year-view {
-    max-width: 1400px;
+    max-width: none;
+    width: 100%;
 }
 
 .year-container {
     display: none;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 10px;
 }
 

--- a/kalender.html
+++ b/kalender.html
@@ -356,7 +356,7 @@
             <button id="toggle-year" class="px-4 py-2 btn-primary text-white rounded-md">Vis år</button>
           </div>
         </div>
-        <div class="calendar-nav flex justify-between gap-2">
+        <div class="calendar-nav flex justify-between gap-2 mb-4">
           <button id="prev-month" class="nav-button px-4 py-2 btn-primary text-white rounded-md">← Forrige</button>
           <button id="next-month" class="nav-button px-4 py-2 btn-primary text-white rounded-md">Neste →</button>
         </div>
@@ -369,7 +369,7 @@
     </section>
 
     <!-- Kollegaseksjon -->
-    <section id="colleague-section" class="colleague-section mb-12">
+    <section id="colleague-section" class="colleague-section mb-12 hidden">
       <h2 class="text-2xl font-semibold text-gray-900 mb-3">Kollegaer i kalenderen</h2>
       <p class="text-gray-700 mb-4">Her ser du kollegaer du allerede har lagt til. For å legge til nye kollegaer, gå til kollega-siden eller <a href="/kollegaer.html" class="text-orange-500 underline">trykk her</a>.</p>
       <div class="colleague-buttons flex gap-2 mb-4">
@@ -393,7 +393,7 @@
     </section>
 
     <!-- Avvik fra turnus -->
-    <section class="mb-12">
+    <section id="deviation-section" class="mb-12 hidden">
       <button id="toggle-deviation" class="btn-primary px-4 py-2 text-white rounded-md mb-4">Legg til avvik fra turnus</button>
       <div id="deviation-form" class="card bg-white shadow-lg rounded-xl p-6 hidden">
         <h3 class="text-xl font-bold text-gray-900 mb-2">Avvik fra egen turnus</h3>
@@ -538,6 +538,8 @@
   const userFirstName = document.getElementById('user-firstname');
   const registerLinks = document.querySelectorAll('a[href="register.html"]');
   const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+  const colleagueSection = document.getElementById('colleague-section');
+  const deviationSection = document.getElementById('deviation-section');
 
     menuBtn.addEventListener('click', () => {
       mobileMenu.classList.toggle('hidden');
@@ -560,8 +562,12 @@
         if (userAvatar && data.user.avatar_url) userAvatar.src = data.user.avatar_url;
         registerLinks.forEach(l => l.classList.add('hidden'));
         friendsLinks.forEach(l => l.classList.remove('hidden'));
+        if (colleagueSection) colleagueSection.classList.remove('hidden');
+        if (deviationSection) deviationSection.classList.remove('hidden');
       } else {
         friendsLinks.forEach(l => l.classList.add('hidden'));
+        if (colleagueSection) colleagueSection.classList.add('hidden');
+        if (deviationSection) deviationSection.classList.add('hidden');
       }
     } catch (e) {
       console.error('Kunne ikke hente brukerinfo:', e);


### PR DESCRIPTION
## Summary
- add spacing below calendar navigation buttons
- hide colleague and deviation sections unless logged in
- expand year view to use full width of screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a564fd0288333b90c4ee6369c8543