### PR TITLE
Fix year calendar layout on desktop

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -16,7 +16,7 @@
 
 .year-container {
     display: none;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
     gap: 10px;
 }
 


### PR DESCRIPTION
## Summary
- maintain four columns in the year view so the whole year fits on a desktop screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a581888188333a3fd5d559bf3bc11