### PR TITLE
Fix turnus overview initialization

### DIFF
--- a/kalender.html
+++ b/kalender.html
@@ -418,7 +418,7 @@
 
     <!-- Turnusoversikt -->
     <section class="mb-12">
-      <div class="turnus-oversikt flex flex-wrap gap-2"></div>
+      <div id="turnus-oversikt" class="turnus-oversikt flex flex-wrap gap-2"></div>
     </section>
 
     <!-- Avvik fra turnus -->
@@ -632,6 +632,7 @@
     // Dummy CSRF-token for kompatibilitet med kalender.js
     window.CSRF_TOKEN = 'dummy-token'; // Erstatt med ekte token fra server
   </script>
+  <script src="js/utils/colors.js"></script>
   <script src="js/kalender.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- give the overview element an id so JS finds it
- load color helpers before `kalender.js`

## Testing
- `tail -n 6 kalender.html`

------
https://chatgpt.com/codex/tasks/task_e_685a60fefe9483338625d931a579e40b