### PR TITLE
Fix missing scripts on calendar page

### DIFF
--- a/kalender.html
+++ b/kalender.html
@@ -633,6 +633,8 @@
     window.CSRF_TOKEN = 'dummy-token'; // Erstatt med ekte token fra server
   </script>
   <script src="js/utils/colors.js"></script>
+  <script src="js/message.js"></script>
+  <script src="js/session.js"></script>
   <script src="js/kalender.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `message.js` and `session.js` in `kalender.html`

This ensures notification messages work and clears stale user data when not logged in.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a633e3ad0833380724687f75b2967