### PR TITLE
Use shared credentials for DB and mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Minturnus Redesign
+
+## Configuration
+
+Create a `backend/config.php` file containing your database and SMTP credentials. Copy the contents of `backend/config.sample.php` and replace the placeholder values:
+
+```php
+<?php
+$servername  = 'localhost';
+$username    = 'db_user';
+$db_password = 'db_password';
+$dbname      = 'database_name';
+
+$smtp_user = 'smtp_user';
+$smtp_pass = 'smtp_password';
+$FACEBOOK_APP_ID = '';
+```
+
+`config.php` is ignored by Git so your sensitive data remains private.

--- a/backend/config.sample.php
+++ b/backend/config.sample.php
@@ -1,0 +1,17 @@
+<?php
+// Sample configuration file for MinTurnus.
+// Copy this file to config.php and fill in your actual credentials.
+
+// Database settings
+$servername  = 'localhost';
+$username    = 'db_user';
+$db_password = 'db_password';
+$dbname      = 'database_name';
+
+// SMTP credentials
+$smtp_user = 'smtp_user';
+$smtp_pass = 'smtp_password';
+
+// Optional: Facebook App ID for login integration
+$FACEBOOK_APP_ID = '';
+

--- a/backend/database.php
+++ b/backend/database.php
@@ -1,15 +1,8 @@
 <?php
-// Load credentials
-$config = require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 
 // Fjern all feilrapportering for produksjon
 error_reporting(0);
-
-// Definer tilkoblingsinformasjon for MySQL-databasen
-$servername = "localhost";            // Vanligvis er det "localhost" for webhotell
-$username = $config['DB_USER'];         // Brukernavnet fra config
-$db_password = $config['DB_PASS'];      // Passordet fra config
-$dbname = "kalende1_turnus";          // Navnet på databasen, inkludert prefixet
 
 // Lag tilkoblingen med MySQLi (denne brukes av andre skript ved behov)
 $conn = new mysqli($servername, $username, $db_password, $dbname);
@@ -28,4 +21,3 @@ $options = [
 ];
 
 // Merk at denne filen nå kun definerer tilkoblingen, og ingen output sendes.
-?>

--- a/backend/get_config.php
+++ b/backend/get_config.php
@@ -1,7 +1,13 @@
 <?php
 header('Content-Type: application/json');
 $configPath = __DIR__ . '/config.php';
-$config = file_exists($configPath) ? require $configPath : [];
-$appId = $config['FACEBOOK_APP_ID'] ?? getenv('FACEBOOK_APP_ID') ?? '';
+$appId = getenv('FACEBOOK_APP_ID') ?: '';
+if (file_exists($configPath)) {
+    include $configPath;
+    if (isset($FACEBOOK_APP_ID)) {
+        $appId = $FACEBOOK_APP_ID;
+    }
+}
 echo json_encode(['facebook_app_id' => $appId]);
+
 

--- a/backend/send_mail.php
+++ b/backend/send_mail.php
@@ -5,6 +5,7 @@ ini_set('display_errors', 1);
 
 session_start();
 require_once 'csrf.php';
+require_once __DIR__ . '/config.php';
 validate_csrf();
 
 use PHPMailer\PHPMailer\PHPMailer;
@@ -13,7 +14,6 @@ use PHPMailer\PHPMailer\Exception;
 require 'PHPMailer/src/Exception.php';
 require 'PHPMailer/src/PHPMailer.php';
 require 'PHPMailer/src/SMTP.php';
-$config = require __DIR__ . '/config.php';
 
 $mail = new PHPMailer(true);
 try {
@@ -21,8 +21,8 @@ try {
     $mail->isSMTP();                                      // Sett SMTP som e-post sendingens metode
     $mail->Host = 'cpanel02.dedia-server.no';             // SMTP-serverens host (fra bildet)
     $mail->SMTPAuth = true;                               // Aktiver SMTP-autentisering
-    $mail->Username = $config['MAIL_USER'];         // SMTP-brukernavn fra config
-    $mail->Password = $config['MAIL_PASS'];         // SMTP-passord fra config
+    $mail->Username = $smtp_user;                        // SMTP-brukernavn fra config
+    $mail->Password = $smtp_pass;                        // SMTP-passord fra config
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;      // Krypteringsmetode (bruk SSL/TLS)
     $mail->Port = 465;                                    // SMTP-port (465 for SSL fra bildet)
 
@@ -40,4 +40,3 @@ try {
 } catch (Exception $e) {
     echo "Meldingen kunne ikke sendes. Mailer Error: {$mail->ErrorInfo}";
 }
-?>


### PR DESCRIPTION
## Summary
- add a `config.sample.php` with placeholder credentials
- reference config variables with absolute paths
- allow `get_config.php` to read variables instead of an array
- document configuration setup in `README`

## Testing
- `php -l backend/database.php` *(fails: command not found)*
- `php -l backend/send_mail.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc2d5d97483338f6999640d3bee6d