### PR TITLE
Implement user avatar menu with notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,35 @@
     .nav-active {
       transform: translateX(0);
     }
+    #user-menu {
+      position: absolute;
+      top: 56px;
+      right: 1rem;
+      background-color: #374151;
+      border-radius: 0.25rem;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      display: none;
+      min-width: 150px;
+      z-index: 50;
+    }
+    #user-menu a {
+      display: block;
+      padding: 8px 16px;
+      color: #fff;
+    }
+    #user-menu a:hover {
+      background-color: #4B5563;
+    }
+    #notification-info {
+      font-size: 0.75rem;
+      color: #D1D5DB;
+      padding: 4px 16px;
+    }
   </style>
 </head>
 <body class="antialiased">
   <!-- Navigasjon -->
-  <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
+  <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50 relative">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
@@ -52,9 +76,14 @@
         <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
-        <div id="user-info" class="ml-4 hidden items-center space-x-2">
+        <div id="user-info" class="ml-4 hidden items-center space-x-2 cursor-pointer">
           <img id="user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
           <span id="user-firstname" class="text-sm"></span>
+        </div>
+        <div id="user-menu">
+          <a href="user_profile.html">Endre profil</a>
+          <a href="friends.html" id="notification-link">Varsler</a>
+          <div id="notification-info"></div>
         </div>
       </div>
     </div>
@@ -107,6 +136,8 @@
   const userInfo = document.getElementById('user-info');
   const userAvatar = document.getElementById('user-avatar');
   const userFirstName = document.getElementById('user-firstname');
+  const userMenu = document.getElementById('user-menu');
+  const notificationInfo = document.getElementById('notification-info');
   const registerLinks = document.querySelectorAll('a[href="register.html"]');
   const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
 
@@ -128,9 +159,16 @@
       if (data.status === 'success' && data.user) {
         if (userInfo) userInfo.classList.remove('hidden');
         if (userFirstName) userFirstName.textContent = data.user.firstname || '';
-        if (userAvatar && data.user.avatar_url) userAvatar.src = data.user.avatar_url;
+        if (userAvatar && data.user.avatar_url) {
+          let src = data.user.avatar_url;
+          if (!src.includes('/') && !src.startsWith('http')) {
+            src = 'uploads/avatars/' + src;
+          }
+          userAvatar.src = src;
+        }
         registerLinks.forEach(l => l.classList.add('hidden'));
         friendsLinks.forEach(l => l.classList.remove('hidden'));
+        updateNotificationText();
       } else {
         friendsLinks.forEach(l => l.classList.add('hidden'));
       }
@@ -156,6 +194,44 @@
     localStorage.setItem('cookieConsent', 'declined');
     cookieConsent.classList.add('hidden');
   });
+
+  function toggleMenu() {
+    if (!userMenu) return;
+    userMenu.style.display = userMenu.style.display === 'block' ? 'none' : 'block';
+  }
+
+  function closeMenu(e) {
+    if (userMenu && !userMenu.contains(e.target) && e.target !== userAvatar && e.target !== userInfo) {
+      userMenu.style.display = 'none';
+    }
+  }
+
+  async function updateNotificationText() {
+    if (!notificationInfo) return;
+    try {
+      const res = await fetch('api/pending_requests.php', { credentials: 'include' });
+      if (!res.ok) return;
+      const requests = await res.json();
+      if (requests.length === 1) {
+        const name = requests[0].user.firstname || 'En kollega';
+        notificationInfo.textContent = `${name} har forespurt om å bli kollega med deg`;
+      } else if (requests.length > 1) {
+        notificationInfo.textContent = `${requests.length} kollegaer har sendt deg en forespørsel`;
+      } else {
+        notificationInfo.textContent = 'Ingen nye forespørsler';
+      }
+    } catch (e) {
+      console.error('Kunne ikke hente varsler:', e);
+    }
+  }
+
+  if (userInfo) {
+    userInfo.addEventListener('click', toggleMenu);
+  }
+  if (userAvatar) {
+    userAvatar.addEventListener('click', toggleMenu);
+  }
+  document.addEventListener('click', closeMenu);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adjust navigation for relative positioning
- add styling and markup for a dropdown menu when clicking user avatar
- show avatar correctly even if only filename is stored
- fetch pending requests to display notification text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bd470849c8333924671aa9be031de