### PR TITLE
Handle missing backend configuration

### DIFF
--- a/backend/database.php
+++ b/backend/database.php
@@ -1,5 +1,16 @@
 <?php
-require_once __DIR__ . '/config.php';
+// Load configuration if present. If missing, return a useful error
+$configFile = __DIR__ . '/config.php';
+if (!file_exists($configFile)) {
+    header('Content-Type: application/json');
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Configuration file missing. Please create backend/config.php.'
+    ]);
+    exit;
+}
+require_once $configFile;
 
 // Fjern all feilrapportering for produksjon
 error_reporting(0);


### PR DESCRIPTION
## Summary
- avoid fatal error if `backend/config.php` is missing

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdce51a248333ac072133ae0e042f