### PR TITLE
Improve login error handling and clarify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ $FACEBOOK_APP_ID = '';
 ```
 
 `config.php` is ignored by Git so your sensitive data remains private.
+
+If you receive a *500 Internal Server Error* when accessing any of the
+`backend/` PHP scripts, ensure that this `config.php` file exists and
+contains valid credentials.

--- a/js/login.js
+++ b/js/login.js
@@ -37,15 +37,22 @@ document.addEventListener('DOMContentLoaded', function () {
                 const responseText = await response.text();
                 if (DEBUG) console.log('Full server response:', responseText);
 
-                if (!response.ok) {
-                    throw new Error(`HTTP-feil! Status: ${response.status}`);
-                }
-
                 let result;
                 try {
                     result = JSON.parse(responseText);
                 } catch (parseError) {
                     if (DEBUG) console.error("Feil ved parsing av JSON:", parseError);
+                    result = null;
+                }
+
+                if (!response.ok) {
+                    const message = result && result.message ? result.message : `HTTP-feil! Status: ${response.status}`;
+                    errorMessages.textContent = message;
+                    errorMessages.style.display = 'block';
+                    return;
+                }
+
+                if (!result) {
                     errorMessages.textContent = "En feil oppstod ved serverkommunikasjon. Vennligst prøv igjen senere.";
                     errorMessages.style.display = 'block';
                     return;


### PR DESCRIPTION
## Summary
- handle backend errors in `js/login.js`
- document the config.php requirement when seeing 500 errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861a3b8978083339c1c73482d989065