### PR TITLE
Handle array style config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ $FACEBOOK_APP_ID = '';
 
 `config.php` is ignored by Git so your sensitive data remains private.
 
+The application also supports an alternative configuration style where the file
+returns an array instead of defining variables:
+
+```php
+<?php
+return [
+    'DB_HOST' => 'localhost',
+    'DB_USER' => 'db_user',
+    'DB_PASS' => 'db_password',
+    'DB_NAME' => 'database_name',
+    'MAIL_USER' => 'smtp_user',
+    'MAIL_PASS' => 'smtp_password'
+];
+```
+
+Either format will be detected automatically.
+
 If you receive a *500 Internal Server Error* when accessing any of the
 `backend/` PHP scripts, ensure that this `config.php` file exists and
 contains valid credentials.

--- a/backend/database.php
+++ b/backend/database.php
@@ -10,7 +10,24 @@ if (!file_exists($configFile)) {
     ]);
     exit;
 }
-require_once $configFile;
+// Include configuration. It can either define variables directly or
+// return an array of settings (legacy format).
+$config = include $configFile;
+
+// If the config file returned an array, map it to variables expected below
+if (is_array($config)) {
+    $servername  = $config['DB_HOST'] ?? 'localhost';
+    $username    = $config['DB_USER'] ?? '';
+    $db_password = $config['DB_PASS'] ?? '';
+    $dbname      = $config['DB_NAME'] ?? '';
+
+    // Optional SMTP/other settings
+    $smtp_user = $config['MAIL_USER'] ?? ($smtp_user ?? null);
+    $smtp_pass = $config['MAIL_PASS'] ?? ($smtp_pass ?? null);
+    if (isset($config['FACEBOOK_APP_ID'])) {
+        $FACEBOOK_APP_ID = $config['FACEBOOK_APP_ID'];
+    }
+}
 
 // Fjern all feilrapportering for produksjon
 error_reporting(0);


### PR DESCRIPTION
## Summary
- handle legacy array-based `config.php` in `database.php`
- document both config styles in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a5ad65f48333bc8cf4e375bfef9c