### PR TITLE
Improve mobile nav for logged-in user

### DIFF
--- a/about.html
+++ b/about.html
@@ -46,6 +46,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -68,6 +72,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
 
@@ -147,8 +153,13 @@
   const userInfo = document.getElementById('user-info');
   const userAvatar = document.getElementById('user-avatar');
   const userFirstName = document.getElementById('user-firstname');
+  const mobileUserLink = document.getElementById('mobile-user-link');
+  const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+  const mobileUserFirstName = document.getElementById('mobile-user-firstname');
   const registerLinks = document.querySelectorAll('a[href="register.html"]');
   const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+  const mobileProfileLink = document.getElementById('mobile-profile-link');
+  const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
     menuBtn.addEventListener('click', () => {
       mobileMenu.classList.toggle('hidden');
@@ -168,7 +179,9 @@
         const data = await res.json();
         if (data.status === 'success' && data.user) {
           if (userInfo) userInfo.classList.remove('hidden');
+          if (mobileUserLink) mobileUserLink.classList.remove('hidden');
           if (userFirstName) userFirstName.textContent = data.user.firstname || '';
+          if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
           if (userAvatar && data.user.avatar_url) {
             let src = data.user.avatar_url;
             if (!src.startsWith('http')) {
@@ -176,9 +189,12 @@
               src = 'https://minturnus.no/' + src;
             }
             userAvatar.src = src;
+            if (mobileUserAvatar) mobileUserAvatar.src = src;
           }
           registerLinks.forEach(l => l.classList.add('hidden'));
           friendsLinks.forEach(l => l.classList.remove('hidden'));
+          if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+          if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
         } else {
           friendsLinks.forEach(l => l.classList.add('hidden'));
         }
@@ -201,7 +217,8 @@
   </script>
   <script>
     const logoutBtn = document.getElementById('logout-btn');
-    logoutBtn?.addEventListener('click', async () => {
+    const mobileLogoutBtn2 = document.getElementById('mobile-logout-btn');
+    const handleLogout = async () => {
       try {
         const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
         const data = await res.json();
@@ -211,7 +228,9 @@
       } catch (e) {
         console.error('Logout feilet:', e);
       }
-    });
+    };
+    logoutBtn?.addEventListener('click', handleLogout);
+    mobileLogoutBtn2?.addEventListener('click', handleLogout);
   </script>
 </body>
 </html>

--- a/change_password.html
+++ b/change_password.html
@@ -23,6 +23,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -45,6 +49,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
 
@@ -85,8 +91,13 @@
       const userInfo = document.getElementById('user-info');
       const userAvatar = document.getElementById('user-avatar');
       const userFirstName = document.getElementById('user-firstname');
+      const mobileUserLink = document.getElementById('mobile-user-link');
+      const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+      const mobileUserFirstName = document.getElementById('mobile-user-firstname');
       const registerLinks = document.querySelectorAll('a[href="register.html"]');
       const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+      const mobileProfileLink = document.getElementById('mobile-profile-link');
+      const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
       menuBtn.addEventListener('click', () => {
         mobileMenu.classList.toggle('hidden');
@@ -105,17 +116,22 @@
           const data = await res.json();
           if (data.status === 'success' && data.user) {
             if (userInfo) userInfo.classList.remove('hidden');
+            if (mobileUserLink) mobileUserLink.classList.remove('hidden');
             if (userFirstName) userFirstName.textContent = data.user.firstname || '';
-              if (userAvatar && data.user.avatar_url) {
-                let src = data.user.avatar_url;
-                if (!src.startsWith('http')) {
-                  src = src.replace(/^\/+/, '');
-                  src = 'https://minturnus.no/' + src;
-                }
-                userAvatar.src = src;
+            if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
+            if (userAvatar && data.user.avatar_url) {
+              let src = data.user.avatar_url;
+              if (!src.startsWith('http')) {
+                src = src.replace(/^\/+/, '');
+                src = 'https://minturnus.no/' + src;
               }
+              userAvatar.src = src;
+              if (mobileUserAvatar) mobileUserAvatar.src = src;
+            }
             registerLinks.forEach(l => l.classList.add('hidden'));
             friendsLinks.forEach(l => l.classList.remove('hidden'));
+            if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+            if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
           } else {
             friendsLinks.forEach(l => l.classList.add('hidden'));
           }
@@ -138,7 +154,8 @@
   </script>
   <script>
     const logoutBtn = document.getElementById('logout-btn');
-    logoutBtn?.addEventListener('click', async () => {
+    const mobileLogoutBtn2 = document.getElementById('mobile-logout-btn');
+    const handleLogout = async () => {
       try {
         const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
         const data = await res.json();
@@ -148,7 +165,9 @@
       } catch (e) {
         console.error('Logout feilet:', e);
       }
-    });
+    };
+    logoutBtn?.addEventListener('click', handleLogout);
+    mobileLogoutBtn2?.addEventListener('click', handleLogout);
   </script>
 </body>
 </html>

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -39,6 +39,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -59,6 +63,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
 
@@ -84,8 +90,13 @@
   const userInfo = document.getElementById('user-info');
   const userAvatar = document.getElementById('user-avatar');
   const userFirstName = document.getElementById('user-firstname');
+  const mobileUserLink = document.getElementById('mobile-user-link');
+  const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+  const mobileUserFirstName = document.getElementById('mobile-user-firstname');
   const registerLinks = document.querySelectorAll('a[href="register.html"]');
   const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+  const mobileProfileLink = document.getElementById('mobile-profile-link');
+  const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
   menuBtn.addEventListener('click', () => {
     mobileMenu.classList.toggle('hidden');
@@ -104,7 +115,9 @@
       const data = await res.json();
       if (data.status === 'success' && data.user) {
         if (userInfo) userInfo.classList.remove('hidden');
+        if (mobileUserLink) mobileUserLink.classList.remove('hidden');
         if (userFirstName) userFirstName.textContent = data.user.firstname || '';
+        if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
         if (userAvatar && data.user.avatar_url) {
           let src = data.user.avatar_url;
           if (!src.startsWith('http')) {
@@ -112,9 +125,12 @@
             src = 'https://minturnus.no/' + src;
           }
           userAvatar.src = src;
+          if (mobileUserAvatar) mobileUserAvatar.src = src;
         }
         registerLinks.forEach(l => l.classList.add('hidden'));
         friendsLinks.forEach(l => l.classList.remove('hidden'));
+        if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+        if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
       } else {
         friendsLinks.forEach(l => l.classList.add('hidden'));
       }
@@ -134,6 +150,19 @@
   declineCookies.addEventListener('click', () => {
     cookieConsent.classList.add('hidden');
   });
+
+  const handleLogout = async () => {
+    try {
+      const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
+      const data = await res.json();
+      if (data.status === 'success') {
+        window.location.href = 'index.html';
+      }
+    } catch (e) {
+      console.error('Logout feilet:', e);
+    }
+  };
+  mobileLogoutBtn?.addEventListener('click', handleLogout);
 </script>
 </body>
 </html>

--- a/friends.html
+++ b/friends.html
@@ -43,6 +43,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -65,6 +69,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
 
@@ -138,9 +144,14 @@
     const closeMenu = document.getElementById('closeMenu');
     const userInfo = document.getElementById('user-info');
     const userAvatar = document.getElementById('user-avatar');
-   const userFirstName = document.getElementById('user-firstname');
-   const registerLinks = document.querySelectorAll('a[href="register.html"]');
+    const userFirstName = document.getElementById('user-firstname');
+    const mobileUserLink = document.getElementById('mobile-user-link');
+    const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+    const mobileUserFirstName = document.getElementById('mobile-user-firstname');
+    const registerLinks = document.querySelectorAll('a[href="register.html"]');
     const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+    const mobileProfileLink = document.getElementById('mobile-profile-link');
+    const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
     menuBtn.addEventListener('click', () => {
       mobileMenu.classList.toggle('hidden');
@@ -158,7 +169,9 @@
         const data = await res.json();
         if (data.status === 'success' && data.user) {
           if (userInfo) userInfo.classList.remove('hidden');
+          if (mobileUserLink) mobileUserLink.classList.remove('hidden');
           if (userFirstName) userFirstName.textContent = data.user.firstname || '';
+          if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
           if (userAvatar && data.user.avatar_url) {
             let src = data.user.avatar_url;
             if (!src.startsWith('http')) {
@@ -166,9 +179,12 @@
               src = 'https://minturnus.no/' + src;
             }
             userAvatar.src = src;
+            if (mobileUserAvatar) mobileUserAvatar.src = src;
           }
           registerLinks.forEach(l => l.classList.add('hidden'));
           friendsLinks.forEach(l => l.classList.remove('hidden'));
+          if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+          if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
         } else {
           friendsLinks.forEach(l => l.classList.add('hidden'));
         }
@@ -195,7 +211,8 @@
   </script>
   <script>
     const logoutBtn = document.getElementById('logout-btn');
-    logoutBtn?.addEventListener('click', async () => {
+    const mobileLogoutBtn2 = document.getElementById('mobile-logout-btn');
+    const handleLogout = async () => {
       try {
         const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
         const data = await res.json();
@@ -205,7 +222,9 @@
       } catch (e) {
         console.error('Logout feilet:', e);
       }
-    });
+    };
+    logoutBtn?.addEventListener('click', handleLogout);
+    mobileLogoutBtn2?.addEventListener('click', handleLogout);
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -93,6 +97,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
 
@@ -134,8 +140,13 @@
   const userInfo = document.getElementById('user-info');
   const userAvatar = document.getElementById('user-avatar');
   const userFirstName = document.getElementById('user-firstname');
+  const mobileUserLink = document.getElementById('mobile-user-link');
+  const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+  const mobileUserFirstName = document.getElementById('mobile-user-firstname');
   const registerLinks = document.querySelectorAll('a[href="register.html"]');
   const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+  const mobileProfileLink = document.getElementById('mobile-profile-link');
+  const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
     menuBtn.addEventListener('click', () => {
       mobileMenu.classList.toggle('hidden');
@@ -155,7 +166,9 @@
         const data = await res.json();
         if (data.status === 'success' && data.user) {
           if (userInfo) userInfo.classList.remove('hidden');
+          if (mobileUserLink) mobileUserLink.classList.remove('hidden');
           if (userFirstName) userFirstName.textContent = data.user.firstname || '';
+          if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
           if (userAvatar && data.user.avatar_url) {
             let src = data.user.avatar_url;
             if (!src.startsWith('http')) {
@@ -163,9 +176,12 @@
               src = 'https://minturnus.no/' + src;
             }
             userAvatar.src = src;
+            if (mobileUserAvatar) mobileUserAvatar.src = src;
           }
           registerLinks.forEach(l => l.classList.add('hidden'));
           friendsLinks.forEach(l => l.classList.remove('hidden'));
+          if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+          if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
         } else {
           friendsLinks.forEach(l => l.classList.add('hidden'));
         }
@@ -188,7 +204,8 @@
   </script>
   <script>
     const logoutBtn = document.getElementById('logout-btn');
-    logoutBtn?.addEventListener('click', async () => {
+    const mobileLogoutBtn2 = document.getElementById('mobile-logout-btn');
+    const handleLogout = async () => {
       try {
         const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
         const data = await res.json();
@@ -198,7 +215,9 @@
       } catch (e) {
         console.error('Logout feilet:', e);
       }
-    });
+    };
+    logoutBtn?.addEventListener('click', handleLogout);
+    mobileLogoutBtn2?.addEventListener('click', handleLogout);
   </script>
 </body>
 </html>

--- a/kalender.html
+++ b/kalender.html
@@ -350,6 +350,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -372,6 +376,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
 
@@ -568,8 +574,13 @@
   const userInfo = document.getElementById('user-info');
   const userAvatar = document.getElementById('user-avatar');
   const userFirstName = document.getElementById('user-firstname');
+  const mobileUserLink = document.getElementById('mobile-user-link');
+  const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+  const mobileUserFirstName = document.getElementById('mobile-user-firstname');
   const registerLinks = document.querySelectorAll('a[href="register.html"]');
   const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+  const mobileProfileLink = document.getElementById('mobile-profile-link');
+  const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
   const colleagueSection = document.getElementById('colleague-section');
   const deviationSection = document.getElementById('deviation-section');
 
@@ -590,7 +601,9 @@
       const data = await res.json();
       if (data.status === 'success' && data.user) {
         if (userInfo) userInfo.classList.remove('hidden');
+        if (mobileUserLink) mobileUserLink.classList.remove('hidden');
         if (userFirstName) userFirstName.textContent = data.user.firstname || '';
+        if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
         if (userAvatar && data.user.avatar_url) {
           let src = data.user.avatar_url;
           if (!src.startsWith('http')) {
@@ -598,9 +611,12 @@
             src = 'https://minturnus.no/' + src;
           }
           userAvatar.src = src;
+          if (mobileUserAvatar) mobileUserAvatar.src = src;
         }
         registerLinks.forEach(l => l.classList.add('hidden'));
         friendsLinks.forEach(l => l.classList.remove('hidden'));
+        if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+        if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
         if (colleagueSection) colleagueSection.classList.remove('hidden');
         if (deviationSection) deviationSection.classList.remove('hidden');
       } else {
@@ -647,7 +663,8 @@
   <script src="js/kalender.js"></script>
   <script>
     const logoutBtn = document.getElementById('logout-btn');
-    logoutBtn?.addEventListener('click', async () => {
+    const mobileLogoutBtn2 = document.getElementById('mobile-logout-btn');
+    const handleLogout = async () => {
       try {
         const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
         const data = await res.json();
@@ -657,7 +674,9 @@
       } catch (e) {
         console.error('Logout feilet:', e);
       }
-    });
+    };
+    logoutBtn?.addEventListener('click', handleLogout);
+    mobileLogoutBtn2?.addEventListener('click', handleLogout);
   </script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -46,6 +46,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalendere</a>
@@ -66,6 +70,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
   <main class="container mx-auto py-12 px-4">
@@ -112,9 +118,14 @@
     const closeMenu = document.getElementById('closeMenu');
     const userInfo = document.getElementById('user-info');
     const userAvatar = document.getElementById('user-avatar');
-   const userFirstName = document.getElementById('user-firstname');
-   const registerLinks = document.querySelectorAll('a[href="register.html"]');
+    const userFirstName = document.getElementById('user-firstname');
+    const mobileUserLink = document.getElementById('mobile-user-link');
+    const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+    const mobileUserFirstName = document.getElementById('mobile-user-firstname');
+    const registerLinks = document.querySelectorAll('a[href="register.html"]');
     const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+    const mobileProfileLink = document.getElementById('mobile-profile-link');
+    const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
     menuBtn.addEventListener('click', () => {
       mobileMenu.classList.toggle('hidden');
@@ -133,7 +144,9 @@
         const data = await res.json();
         if (data.status === 'success' && data.user) {
           if (userInfo) userInfo.classList.remove('hidden');
+          if (mobileUserLink) mobileUserLink.classList.remove('hidden');
           if (userFirstName) userFirstName.textContent = data.user.firstname || '';
+          if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
           if (userAvatar && data.user.avatar_url) {
             let src = data.user.avatar_url;
             if (!src.startsWith('http')) {
@@ -141,9 +154,12 @@
               src = 'https://minturnus.no/' + src;
             }
             userAvatar.src = src;
+            if (mobileUserAvatar) mobileUserAvatar.src = src;
           }
           registerLinks.forEach(l => l.classList.add('hidden'));
           friendsLinks.forEach(l => l.classList.remove('hidden'));
+          if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+          if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
         } else {
           friendsLinks.forEach(l => l.classList.add('hidden'));
         }
@@ -165,10 +181,23 @@
       cookieConsent.classList.add('hidden');
     });
 
-    declineCookies.addEventListener('click', () => {
-      localStorage.setItem('cookieConsent', 'declined');
-      cookieConsent.classList.add('hidden');
-    });
+  declineCookies.addEventListener('click', () => {
+    localStorage.setItem('cookieConsent', 'declined');
+    cookieConsent.classList.add('hidden');
+  });
+
+  const handleLogout = async () => {
+    try {
+      const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
+      const data = await res.json();
+      if (data.status === 'success') {
+        window.location.href = 'index.html';
+      }
+    } catch (e) {
+      console.error('Logout feilet:', e);
+    }
+  };
+  mobileLogoutBtn?.addEventListener('click', handleLogout);
   </script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -44,6 +44,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -64,6 +68,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
     
@@ -135,9 +141,14 @@
     const closeMenu = document.getElementById('closeMenu');
     const userInfo = document.getElementById('user-info');
     const userAvatar = document.getElementById('user-avatar');
-   const userFirstName = document.getElementById('user-firstname');
-   const registerLinks = document.querySelectorAll('a[href="register.html"]');
+    const userFirstName = document.getElementById('user-firstname');
+    const mobileUserLink = document.getElementById('mobile-user-link');
+    const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+    const mobileUserFirstName = document.getElementById('mobile-user-firstname');
+    const registerLinks = document.querySelectorAll('a[href="register.html"]');
     const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+    const mobileProfileLink = document.getElementById('mobile-profile-link');
+    const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
     menuBtn.addEventListener('click', () => {
       mobileMenu.classList.toggle('hidden');
@@ -156,7 +167,9 @@
         const data = await res.json();
         if (data.status === 'success' && data.user) {
           if (userInfo) userInfo.classList.remove('hidden');
+          if (mobileUserLink) mobileUserLink.classList.remove('hidden');
           if (userFirstName) userFirstName.textContent = data.user.firstname || '';
+          if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
           if (userAvatar && data.user.avatar_url) {
             let src = data.user.avatar_url;
             if (!src.startsWith('http')) {
@@ -164,9 +177,12 @@
               src = 'https://minturnus.no/' + src;
             }
             userAvatar.src = src;
+            if (mobileUserAvatar) mobileUserAvatar.src = src;
           }
           registerLinks.forEach(l => l.classList.add('hidden'));
           friendsLinks.forEach(l => l.classList.remove('hidden'));
+          if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+          if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
         } else {
           friendsLinks.forEach(l => l.classList.add('hidden'));
         }
@@ -188,10 +204,23 @@
       cookieConsent.classList.add('hidden');
     });
 
-    declineCookies.addEventListener('click', () => {
-      localStorage.setItem('cookieConsent', 'declined');
-      cookieConsent.classList.add('hidden');
-    });
+  declineCookies.addEventListener('click', () => {
+    localStorage.setItem('cookieConsent', 'declined');
+    cookieConsent.classList.add('hidden');
+  });
+
+  const handleLogout = async () => {
+    try {
+      const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
+      const data = await res.json();
+      if (data.status === 'success') {
+        window.location.href = 'index.html';
+      }
+    } catch (e) {
+      console.error('Logout feilet:', e);
+    }
+  };
+  mobileLogoutBtn?.addEventListener('click', handleLogout);
   </script>
 </body>
 </html>

--- a/user_profile.html
+++ b/user_profile.html
@@ -19,6 +19,10 @@
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
       <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
+        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        <span id="mobile-user-firstname" class="text-sm"></span>
+      </a>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
@@ -40,6 +44,8 @@
       <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
+      <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>
+      <button id="mobile-logout-btn" class="block py-2 text-left hover:text-orange-400 hidden">Logg ut</button>
     </div>
   </nav>
 
@@ -170,8 +176,13 @@
       const userInfo = document.getElementById('user-info');
       const userAvatar = document.getElementById('user-avatar');
       const userFirstName = document.getElementById('user-firstname');
+      const mobileUserLink = document.getElementById('mobile-user-link');
+      const mobileUserAvatar = document.getElementById('mobile-user-avatar');
+      const mobileUserFirstName = document.getElementById('mobile-user-firstname');
       const registerLinks = document.querySelectorAll('a[href="register.html"]');
       const friendsLinks = document.querySelectorAll('a[href="friends.html"]');
+      const mobileProfileLink = document.getElementById('mobile-profile-link');
+      const mobileLogoutBtn = document.getElementById('mobile-logout-btn');
 
       menuBtn.addEventListener('click', () => {
         mobileMenu.classList.toggle('hidden');
@@ -190,17 +201,22 @@
           const data = await res.json();
           if (data.status === 'success' && data.user) {
             if (userInfo) userInfo.classList.remove('hidden');
+            if (mobileUserLink) mobileUserLink.classList.remove('hidden');
             if (userFirstName) userFirstName.textContent = data.user.firstname || '';
-              if (userAvatar && data.user.avatar_url) {
-                let src = data.user.avatar_url;
-                if (!src.startsWith('http')) {
-                  src = src.replace(/^\/+/, '');
-                  src = 'https://minturnus.no/' + src;
-                }
-                userAvatar.src = src;
+            if (mobileUserFirstName) mobileUserFirstName.textContent = data.user.firstname || '';
+            if (userAvatar && data.user.avatar_url) {
+              let src = data.user.avatar_url;
+              if (!src.startsWith('http')) {
+                src = src.replace(/^\/+/, '');
+                src = 'https://minturnus.no/' + src;
               }
+              userAvatar.src = src;
+              if (mobileUserAvatar) mobileUserAvatar.src = src;
+            }
             registerLinks.forEach(l => l.classList.add('hidden'));
             friendsLinks.forEach(l => l.classList.remove('hidden'));
+            if (mobileProfileLink) mobileProfileLink.classList.remove('hidden');
+            if (mobileLogoutBtn) mobileLogoutBtn.classList.remove('hidden');
           } else {
             friendsLinks.forEach(l => l.classList.add('hidden'));
           }
@@ -229,7 +245,8 @@
     </script>
     <script>
       const logoutBtn = document.getElementById('logout-btn');
-      logoutBtn?.addEventListener('click', async () => {
+      const mobileLogoutBtn2 = document.getElementById('mobile-logout-btn');
+      const handleLogout = async () => {
         try {
           const res = await fetch('backend/logout.php', { method: 'POST', credentials: 'include' });
           const data = await res.json();
@@ -239,7 +256,9 @@
         } catch (e) {
           console.error('Logout feilet:', e);
         }
-      });
+      };
+      logoutBtn?.addEventListener('click', handleLogout);
+      mobileLogoutBtn2?.addEventListener('click', handleLogout);
     </script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- show user's avatar and name next to hamburger icon when logged in
- add "Profil" and "Logg ut" entries inside the mobile menu
- handle logout from both desktop and mobile menu
- update all pages using the responsive navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68659a094c3c83338e46736f4c0c6b07