### PR TITLE
Fix mobile nav layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,11 +45,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>

--- a/change_password.html
+++ b/change_password.html
@@ -22,11 +22,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -38,11 +38,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>

--- a/friends.html
+++ b/friends.html
@@ -42,11 +42,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>

--- a/index.html
+++ b/index.html
@@ -70,11 +70,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>

--- a/kalender.html
+++ b/kalender.html
@@ -349,11 +349,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>

--- a/login.html
+++ b/login.html
@@ -45,11 +45,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalendere</a>

--- a/register.html
+++ b/register.html
@@ -43,11 +43,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>

--- a/user_profile.html
+++ b/user_profile.html
@@ -18,11 +18,13 @@
   <nav class="bg-gray-900 text-white p-4 sticky top-0 z-50">
     <div class="container mx-auto flex justify-between items-center">
       <a href="index.html" class="text-2xl font-bold"><span class="text-white">Min</span><span class="accent-text">Turnus</span></a>
-      <button id="menuBtn" class="text-3xl md:hidden text-orange-400 focus:outline-none">☰</button>
-      <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 md:hidden hidden">
-        <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
-        <span id="mobile-user-firstname" class="text-sm"></span>
-      </a>
+      <div class="flex items-center space-x-2 md:hidden">
+        <a href="user_profile.html" id="mobile-user-link" class="flex items-center space-x-2 hidden">
+          <span id="mobile-user-firstname" class="text-sm"></span>
+          <img id="mobile-user-avatar" src="" alt="Avatar" class="w-8 h-8 rounded-full object-cover">
+        </a>
+        <button id="menuBtn" class="text-3xl text-orange-400 focus:outline-none">☰</button>
+      </div>
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>


### PR DESCRIPTION
## Summary
- group avatar, name and menu icon on the right side for mobile
- show first name before avatar

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68659de5c4b083338f940582465b51c2