### PR TITLE
Fix navbar color and rename Friends link

### DIFF
--- a/about.html
+++ b/about.html
@@ -55,7 +55,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden flex items-center space-x-3">
@@ -71,7 +71,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/change_password.html
+++ b/change_password.html
@@ -32,7 +32,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden flex items-center space-x-3">
@@ -48,7 +48,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -48,7 +48,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden items-center space-x-2">
@@ -62,7 +62,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/friends.html
+++ b/friends.html
@@ -52,7 +52,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden flex items-center space-x-3">
@@ -68,7 +68,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden flex items-center space-x-3">
@@ -96,7 +96,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/kalender.html
+++ b/kalender.html
@@ -359,7 +359,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden flex items-center space-x-3">
@@ -375,7 +375,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/login.html
+++ b/login.html
@@ -55,7 +55,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalendere</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden items-center space-x-2">
@@ -69,7 +69,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/register.html
+++ b/register.html
@@ -53,7 +53,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden items-center space-x-2">
@@ -67,7 +67,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>

--- a/user_profile.html
+++ b/user_profile.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="css/user_profile.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/user_profile.js"></script>
+<style>nav.bg-gray-900{background-color:#111827!important;}</style>
 </head>
 <body>
   <!-- Navigasjon -->
@@ -29,7 +30,7 @@
       <div id="navLinks" class="hidden md:flex space-x-6 items-center">
         <a href="index.html" class="hover:text-orange-400 transition-colors">Hjem</a>
         <a href="kalender.html" class="hover:text-orange-400 transition-colors">Kalender</a>
-        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Friends</a>
+        <a href="friends.html" class="friends-link hidden hover:text-orange-400 transition-colors">Kollegaer</a>
         <a href="about.html" class="hover:text-orange-400 transition-colors">Om oss</a>
         <a href="register.html" class="register-link hover:text-orange-400 transition-colors">Opprett profil</a>
         <div id="user-info" class="ml-4 hidden flex items-center space-x-3">
@@ -45,7 +46,7 @@
       <button id="closeMenu" class="text-2xl mb-4 text-orange-400">✕</button>
       <a href="index.html" class="block py-2 hover:text-orange-400">Hjem</a>
       <a href="kalender.html" class="block py-2 hover:text-orange-400">Kalender</a>
-      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Friends</a>
+      <a href="friends.html" class="friends-link block py-2 hover:text-orange-400 hidden">Kollegaer</a>
       <a href="about.html" class="block py-2 hover:text-orange-400">Om oss</a>
       <a href="register.html" class="register-link block py-2 hover:text-orange-400">Opprett profil</a>
       <a href="user_profile.html" id="mobile-profile-link" class="block py-2 hover:text-orange-400 hidden">Profil</a>


### PR DESCRIPTION
## Summary
- adjust navbar color on user profile page to match other pages
- show "Kollegaer" instead of "Friends" in navigation links

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`
- `make test` *(fails: no rule `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6865a39a16fc8333b292cd48e055f435