### PR TITLE
Persist colleague colors via backend

### DIFF
--- a/api/colleague_colors.php
+++ b/api/colleague_colors.php
@@ -1,0 +1,64 @@
+<?php
+session_start();
+require_once __DIR__ . '/../backend/database.php';
+require_once __DIR__ . '/../backend/csrf.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Not logged in']);
+    exit;
+}
+
+$uid = $_SESSION['user_id'];
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    $stmt = $conn->prepare('SELECT colleague_id, color FROM colleague_colors WHERE user_id=?');
+    $stmt->bind_param('i', $uid);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $prefs = [];
+    while ($row = $res->fetch_assoc()) {
+        $prefs[(int)$row['colleague_id']] = $row['color'];
+    }
+    echo json_encode($prefs);
+    exit;
+}
+
+validate_csrf();
+
+$input = json_decode(file_get_contents('php://input'), true);
+$id = $input['id'] ?? 0;
+if (!$id) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid id']);
+    exit;
+}
+
+if ($method === 'POST') {
+    $color = $input['color'] ?? '';
+    if (!$color) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'No color']);
+        exit;
+    }
+    $conn->begin_transaction();
+    $del = $conn->prepare('DELETE FROM colleague_colors WHERE user_id=? AND color=?');
+    $del->bind_param('is', $uid, $color);
+    $del->execute();
+    $stmt = $conn->prepare('REPLACE INTO colleague_colors (user_id, colleague_id, color) VALUES (?, ?, ?)');
+    $stmt->bind_param('iis', $uid, $id, $color);
+    $stmt->execute();
+    $conn->commit();
+    echo json_encode(['status' => 'success']);
+} elseif ($method === 'DELETE') {
+    $stmt = $conn->prepare('DELETE FROM colleague_colors WHERE user_id=? AND colleague_id=?');
+    $stmt->bind_param('ii', $uid, $id);
+    $stmt->execute();
+    echo json_encode(['status' => 'success']);
+} else {
+    http_response_code(405);
+    echo json_encode(['status' => 'error', 'message' => 'Method not allowed']);
+}

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -188,9 +188,16 @@ function createCard(user, options = {}) {
         sel.addEventListener('click', e => e.stopPropagation());
         sel.onchange = e => {
             const val = e.target.value;
-            if (val) colorPrefs[user.id] = val; else delete colorPrefs[user.id];
-            localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
-            updateColorOptions();
+            fetch('api/colleague_colors.php', {
+                credentials: 'include',
+                method: val ? 'POST' : 'DELETE',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
+                body: JSON.stringify({ id: user.id, color: val })
+            }).then(() => {
+                if (val) colorPrefs[user.id] = val; else delete colorPrefs[user.id];
+                localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
+                updateColorOptions();
+            });
         };
         settings.appendChild(sel);
 
@@ -342,8 +349,21 @@ function getNextAvailableColor() {
 }
 
 function loadColleagueColorPrefs() {
-  const s = localStorage.getItem('colleagueColorPref');
-  colleagueColorPref = s ? JSON.parse(s) : {};
+  if (!localStorage.getItem('userName')) {
+    const s = localStorage.getItem('colleagueColorPref');
+    colleagueColorPref = s ? JSON.parse(s) : {};
+    return;
+  }
+  fetch('api/colleague_colors.php', { credentials: 'include' })
+    .then(r => r.json())
+    .then(prefs => {
+      colleagueColorPref = prefs;
+      localStorage.setItem('colleagueColorPref', JSON.stringify(colleagueColorPref));
+    })
+    .catch(() => {
+      const s = localStorage.getItem('colleagueColorPref');
+      colleagueColorPref = s ? JSON.parse(s) : {};
+    });
 }
 
 function loadCloseColleagues() {

--- a/js/bundle.min.js
+++ b/js/bundle.min.js
@@ -188,9 +188,11 @@ function createCard(user, options = {}) {
         sel.addEventListener('click', e => e.stopPropagation());
         sel.onchange = e => {
             const val = e.target.value;
-            if (val) colorPrefs[user.id] = val; else delete colorPrefs[user.id];
-            localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
-            updateColorOptions();
+            fetch('api/colleague_colors.php', {credentials:'include',method:val?'POST':'DELETE',headers:{'Content-Type':'application/json','X-CSRF-Token':window.CSRF_TOKEN},body:JSON.stringify({id:user.id,color:val})}).then(()=>{
+                if(val) colorPrefs[user.id]=val; else delete colorPrefs[user.id];
+                localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
+                updateColorOptions();
+            });
         };
         settings.appendChild(sel);
 
@@ -341,10 +343,7 @@ function getNextAvailableColor() {
   return allColors.find(c => !usedColors.includes(c));
 }
 
-function loadColleagueColorPrefs() {
-  const s = localStorage.getItem('colleagueColorPref');
-  colleagueColorPref = s ? JSON.parse(s) : {};
-}
+function loadColleagueColorPrefs(){if(!localStorage.getItem("userName")){const s=localStorage.getItem("colleagueColorPref");colleagueColorPref=s?JSON.parse(s):{};return}fetch("api/colleague_colors.php",{credentials:"include"}).then(r=>r.json()).then(prefs=>{colleagueColorPref=prefs;localStorage.setItem("colleagueColorPref",JSON.stringify(colleagueColorPref))}).catch(()=>{const s=localStorage.getItem("colleagueColorPref");colleagueColorPref=s?JSON.parse(s):{}})}
 
 function loadCloseColleagues() {
   if (!localStorage.getItem('userName')) {

--- a/js/friends.js
+++ b/js/friends.js
@@ -4,7 +4,14 @@ let closePrefs = {};
 document.addEventListener('DOMContentLoaded', () => {
     const stored = localStorage.getItem('colleagueColorPref');
     colorPrefs = stored ? JSON.parse(stored) : {};
-    fetch('api/close_colleagues.php', { credentials: 'include' })
+    const colorsPromise = fetch('api/colleague_colors.php', { credentials: 'include' })
+        .then(r => r.json())
+        .then(prefs => {
+            colorPrefs = prefs;
+            localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
+        })
+        .catch(() => {});
+    const closePromise = fetch('api/close_colleagues.php', { credentials: 'include' })
         .then(r => r.json())
         .then(ids => {
             closePrefs = {};
@@ -16,7 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
             closePrefs = closeStored ? JSON.parse(closeStored) : {};
         });
     loadPendingRequests();
-    loadColleagues();
+    Promise.all([colorsPromise, closePromise]).then(() => {
+        updateColorOptions();
+        loadColleagues();
+    });
 
     document.getElementById('search-btn')
         .addEventListener('click', searchUsers);

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -51,8 +51,21 @@ function getNextAvailableColor() {
 }
 
 function loadColleagueColorPrefs() {
-  const s = localStorage.getItem('colleagueColorPref');
-  colleagueColorPref = s ? JSON.parse(s) : {};
+  if (!localStorage.getItem('userName')) {
+    const s = localStorage.getItem('colleagueColorPref');
+    colleagueColorPref = s ? JSON.parse(s) : {};
+    return;
+  }
+  fetch('api/colleague_colors.php', { credentials: 'include' })
+    .then(r => r.json())
+    .then(prefs => {
+      colleagueColorPref = prefs;
+      localStorage.setItem('colleagueColorPref', JSON.stringify(colleagueColorPref));
+    })
+    .catch(() => {
+      const s = localStorage.getItem('colleagueColorPref');
+      colleagueColorPref = s ? JSON.parse(s) : {};
+    });
 }
 
 function loadCloseColleagues() {

--- a/js/user_card.js
+++ b/js/user_card.js
@@ -129,9 +129,16 @@ function createCard(user, options = {}) {
         sel.addEventListener('click', e => e.stopPropagation());
         sel.onchange = e => {
             const val = e.target.value;
-            if (val) colorPrefs[user.id] = val; else delete colorPrefs[user.id];
-            localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
-            updateColorOptions();
+            fetch('api/colleague_colors.php', {
+                credentials: 'include',
+                method: val ? 'POST' : 'DELETE',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
+                body: JSON.stringify({ id: user.id, color: val })
+            }).then(() => {
+                if (val) colorPrefs[user.id] = val; else delete colorPrefs[user.id];
+                localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
+                updateColorOptions();
+            });
         };
         settings.appendChild(sel);
 


### PR DESCRIPTION
## Summary
- add API endpoint to persist selected colleague colors
- store color selection on the server when changed
- sync color preferences from server for friends and calendar

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866a08b1e188333b51554fcdfd9d70b