### PR TITLE
Improve API robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ return [
 
 Either format will be detected automatically.
 
+When you run the application for the first time, the `api/colleague_colors.php`
+endpoint will automatically create the `colleague_colors` table if it does not
+already exist.
+
 If you receive a *500 Internal Server Error* when accessing any of the
 `backend/` PHP scripts, ensure that this `config.php` file exists and
 contains valid credentials.

--- a/api/colleague_colors.php
+++ b/api/colleague_colors.php
@@ -3,6 +3,25 @@ session_start();
 require_once __DIR__ . '/../backend/database.php';
 require_once __DIR__ . '/../backend/csrf.php';
 
+// Ensure the table exists so queries below don't fail on a new installation
+$conn->query("CREATE TABLE IF NOT EXISTS colleague_colors (
+    user_id INT NOT NULL,
+    colleague_id INT NOT NULL,
+    color VARCHAR(7) NOT NULL,
+    PRIMARY KEY (user_id, colleague_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+function safe_stmt($conn, $sql)
+{
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        http_response_code(500);
+        echo json_encode(['status' => 'error', 'message' => 'Database error']);
+        exit;
+    }
+    return $stmt;
+}
+
 header('Content-Type: application/json');
 
 if (!isset($_SESSION['user_id'])) {
@@ -15,7 +34,7 @@ $uid = $_SESSION['user_id'];
 $method = $_SERVER['REQUEST_METHOD'];
 
 if ($method === 'GET') {
-    $stmt = $conn->prepare('SELECT colleague_id, color FROM colleague_colors WHERE user_id=?');
+    $stmt = safe_stmt($conn, 'SELECT colleague_id, color FROM colleague_colors WHERE user_id=?');
     $stmt->bind_param('i', $uid);
     $stmt->execute();
     $res = $stmt->get_result();
@@ -45,16 +64,16 @@ if ($method === 'POST') {
         exit;
     }
     $conn->begin_transaction();
-    $del = $conn->prepare('DELETE FROM colleague_colors WHERE user_id=? AND color=?');
+    $del = safe_stmt($conn, 'DELETE FROM colleague_colors WHERE user_id=? AND color=?');
     $del->bind_param('is', $uid, $color);
     $del->execute();
-    $stmt = $conn->prepare('REPLACE INTO colleague_colors (user_id, colleague_id, color) VALUES (?, ?, ?)');
+    $stmt = safe_stmt($conn, 'REPLACE INTO colleague_colors (user_id, colleague_id, color) VALUES (?, ?, ?)');
     $stmt->bind_param('iis', $uid, $id, $color);
     $stmt->execute();
     $conn->commit();
     echo json_encode(['status' => 'success']);
 } elseif ($method === 'DELETE') {
-    $stmt = $conn->prepare('DELETE FROM colleague_colors WHERE user_id=? AND colleague_id=?');
+    $stmt = safe_stmt($conn, 'DELETE FROM colleague_colors WHERE user_id=? AND colleague_id=?');
     $stmt->bind_param('ii', $uid, $id);
     $stmt->execute();
     echo json_encode(['status' => 'success']);

--- a/backend/database.php
+++ b/backend/database.php
@@ -1,15 +1,39 @@
 <?php
 // Load credentials
-$config = require __DIR__ . '/config.php';
+$configPath = __DIR__ . '/config.php';
+if (!file_exists($configPath)) {
+    http_response_code(500);
+    die('Missing backend/config.php');
+}
+$config = require $configPath;
+
+// Support both array style and variable style config
+if (is_array($config)) {
+    $servername  = $config['DB_HOST'] ?? 'localhost';
+    $username    = $config['DB_USER'] ?? '';
+    $db_password = $config['DB_PASS'] ?? '';
+    $dbname      = $config['DB_NAME'] ?? '';
+} else {
+    $servername = $servername ?? 'localhost';
+    $username = $username ?? '';
+    $db_password = $db_password ?? '';
+    $dbname = $dbname ?? '';
+}
 
 // Fjern all feilrapportering for produksjon
-error_reporting(0);
+if (getenv('DEV_MODE')) {
+    error_reporting(E_ALL);
+    ini_set('display_errors', 1);
+} else {
+    error_reporting(0);
+}
 
 // Definer tilkoblingsinformasjon for MySQL-databasen
-$servername = "localhost";            // Vanligvis er det "localhost" for webhotell
-$username = $config['DB_USER'];         // Brukernavnet fra config
-$db_password = $config['DB_PASS'];      // Passordet fra config
-$dbname = "kalende1_turnus";          // Navnet på databasen, inkludert prefixet
+// Config values override the defaults defined above
+$servername = $servername ?: 'localhost';
+$username = $username ?: '';
+$db_password = $db_password ?: '';
+$dbname = $dbname ?: '';
 
 // Lag tilkoblingen med MySQLi (denne brukes av andre skript ved behov)
 $conn = new mysqli($servername, $username, $db_password, $dbname);


### PR DESCRIPTION
## Summary
- create colleague_colors table on demand and guard DB operations
- load database config safely and expose errors in DEV_MODE
- document automatic table creation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866a470f8a483338a32de31bec0abbf