### PR TITLE
Improve colleague card visuals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -458,11 +458,11 @@ a:hover {
 /* Kortdesign for brukere */
 .user-card {
     display: flex;
-    gap: 15px;
-    padding: 16px;
-    border-radius: 16px;
+    gap: 10px;
+    padding: 12px;
+    border-radius: 12px;
     background: linear-gradient(135deg, #ffffff, #f9fafb);
-    box-shadow: 0 3px 10px rgba(0,0,0,0.08);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
     align-items: center;
     position: relative;
     overflow: hidden;
@@ -470,8 +470,8 @@ a:hover {
 }
 
 .user-card:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 12px 25px rgba(0,0,0,0.15);
+    transform: translateY(-4px);
+    box-shadow: 0 8px 18px rgba(0,0,0,0.12);
 }
 
 .user-card.compact {
@@ -510,15 +510,15 @@ a:hover {
 .user-card .avatar {
     position: relative;
     border-radius: 50%;
-    padding: 3px;
+    padding: 2px;
     background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
     display: inline-flex;
-    box-shadow: 0 4px 10px rgba(249,115,22,0.3);
+    box-shadow: 0 3px 8px rgba(249,115,22,0.25);
 }
 
 .user-card .avatar-img {
-    width: 90px;
-    height: 90px;
+    width: 72px;
+    height: 72px;
     border-radius: 50%;
     background: var(--secondary-color);
     display: flex;
@@ -526,7 +526,7 @@ a:hover {
     justify-content: center;
     background-size: cover;
     background-position: center;
-    font-size: 36px;
+    font-size: 30px;
     color: var(--light-color);
     box-shadow: inset 0 0 0 3px #fff;
     flex-shrink: 0;
@@ -579,14 +579,14 @@ a:hover {
 }
 
 .user-card .user-info .name {
-    font-size: 1.25rem;
+    font-size: 1.1rem;
     font-weight: 600;
-    margin-bottom: 4px;
+    margin-bottom: 2px;
 }
 .user-card .user-info p {
     margin-bottom: 2px;
     line-height: 1.3;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
 }
 .user-card .user-info p strong {
     color: var(--accent-color);
@@ -615,6 +615,62 @@ a:hover {
 }
 .settings-row select {
     flex: 1;
+}
+
+/* New color picker */
+.color-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    flex: 1;
+}
+.color-swatch {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.color-swatch.selected {
+    box-shadow: 0 0 0 2px #000;
+    transform: scale(1.1);
+}
+.color-swatch.disabled {
+    opacity: 0.3;
+    pointer-events: none;
+}
+
+.close-label input[type="checkbox"] {
+    appearance: none;
+    width: 34px;
+    height: 18px;
+    background: #ddd;
+    border-radius: 9999px;
+    position: relative;
+    outline: none;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+.close-label input[type="checkbox"]::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.2s ease;
+}
+.close-label input[type="checkbox"]:checked {
+    background: var(--accent-color);
+}
+.close-label input[type="checkbox"]:checked::after {
+    transform: translateX(16px);
+}
+.close-label span {
+    margin-left: 6px;
 }
 
 .fade {

--- a/js/friends.js
+++ b/js/friends.js
@@ -126,11 +126,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
 function updateColorOptions() {
     const used = new Set(Object.values(colorPrefs).filter(c => c));
-    document.querySelectorAll('#colleagues-list select').forEach(sel => {
-        const current = sel.value;
-        Array.from(sel.options).forEach(opt => {
-            if (!opt.value) return;
-            opt.disabled = used.has(opt.value) && opt.value !== current;
+    document.querySelectorAll('#colleagues-list .color-picker').forEach(picker => {
+        const userId = picker.closest('.user-card')?.dataset.userid;
+        const current = colorPrefs[userId] || '';
+        picker.querySelectorAll('.color-swatch').forEach(sw => {
+            const val = sw.dataset.color || '';
+            const unavailable = val && used.has(val) && val !== current;
+            sw.classList.toggle('disabled', unavailable);
         });
     });
 }

--- a/js/user_card.js
+++ b/js/user_card.js
@@ -2,6 +2,7 @@
 function createCard(user, options = {}) {
     const card = document.createElement('div');
     card.className = 'user-card colleague-card fade';
+    card.dataset.userid = user.id;
     if (options.compact) card.classList.add('compact');
     if (options.mini) card.classList.add('mini');
 
@@ -122,22 +123,25 @@ function createCard(user, options = {}) {
         const settings = document.createElement('div');
         settings.className = 'settings-row';
 
-        const sel = document.createElement('select');
-        const autoOpt = document.createElement('option');
-        autoOpt.value = '';
-        autoOpt.textContent = 'Auto';
-        sel.appendChild(autoOpt);
-        allColors.forEach(c => {
-            const o = document.createElement('option');
-            o.value = c;
-            o.textContent = colorNames[c] || c;
-            o.style.backgroundColor = c;
-            sel.appendChild(o);
-        });
-        sel.value = colorPrefs[user.id] || '';
-        sel.addEventListener('click', e => e.stopPropagation());
-        sel.onchange = e => {
-            const val = e.target.value;
+        const picker = document.createElement('div');
+        picker.className = 'color-picker';
+        const createSwatch = (col, label) => {
+            const sw = document.createElement('div');
+            sw.className = 'color-swatch';
+            sw.dataset.color = col;
+            if (col) sw.style.backgroundColor = col; else sw.textContent = label;
+            if ((colorPrefs[user.id] || '') === col) sw.classList.add('selected');
+            picker.appendChild(sw);
+        };
+        createSwatch('', 'A');
+        allColors.forEach(c => createSwatch(c));
+        picker.addEventListener('click', e => {
+            const sw = e.target.closest('.color-swatch');
+            if (!sw) return;
+            e.stopPropagation();
+            picker.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
+            sw.classList.add('selected');
+            const val = sw.dataset.color || '';
             fetch('api/colleague_colors.php', {
                 credentials: 'include',
                 method: val ? 'POST' : 'DELETE',
@@ -148,8 +152,8 @@ function createCard(user, options = {}) {
                 localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
                 updateColorOptions();
             });
-        };
-        settings.appendChild(sel);
+        });
+        settings.appendChild(picker);
 
         const lbl = document.createElement('label');
         lbl.className = 'close-label';


### PR DESCRIPTION
## Summary
- redesign user cards with tighter spacing and smaller avatars
- replace color dropdown with modern color picker
- style near-colleague checkbox as a toggle switch
- update color option logic to work with the new picker

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687d6078ad48833396f0110b99796f77